### PR TITLE
Add stmt:bindkv(table)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -596,9 +596,11 @@ end
 function stmt_mt:bindkv(t, pre) T_open(self)
   pre = pre or ":"
   for k,v in pairs(t) do
-    local param = sql.sqlite3_bind_parameter_index(self._ptr, pre..k)
-    if param ~= 0 then
-      self:_bind1(param, v)
+    if type(k) == "string" then
+      local param = sql.sqlite3_bind_parameter_index(self._ptr, pre..k)
+      if param ~= 0 then
+        self:_bind1(param, v)
+      end
     end
   end
   return self

--- a/init.lua
+++ b/init.lua
@@ -4,8 +4,8 @@
 -- Copyright (C) 2011-2016 Stefano Peluchetti. All rights reserved.
 --
 -- Features, documentation and more: http://www.scilua.org .
--- 
--- This file is part of the LJSQLite3 library, which is released under the MIT 
+--
+-- This file is part of the LJSQLite3 library, which is released under the MIT
 -- license: full text in file LICENSE.TXT in the library's root folder.
 --------------------------------------------------------------------------------
 
@@ -15,7 +15,7 @@
 -- TODO: Add extended error codes from Sqlite?
 -- TODO: Consider type checks?
 -- TODO: Exposed cdef constants are ok?
--- TODO: Resultset (and so exec) could be optimized by avoiding loads/stores 
+-- TODO: Resultset (and so exec) could be optimized by avoiding loads/stores
 -- TODO: of row table via _step?
 
 local ffi  = require "ffi"
@@ -31,9 +31,9 @@ end
 -- Codes -----------------------------------------------------------------------
 local sqlconstants = {} -- SQLITE_* and OPEN_* declarations.
 local codes = {
-  [0] = "OK", "ERROR", "INTERNAL", "PERM", "ABORT", "BUSY", "LOCKED", "NOMEM", 
-  "READONLY", "INTERRUPT", "IOERR", "CORRUPT", "NOTFOUND", "FULL", "CANTOPEN", 
-  "PROTOCOL", "EMPTY", "SCHEMA", "TOOBIG", "CONSTRAINT", "MISMATCH", "MISUSE", 
+  [0] = "OK", "ERROR", "INTERNAL", "PERM", "ABORT", "BUSY", "LOCKED", "NOMEM",
+  "READONLY", "INTERRUPT", "IOERR", "CORRUPT", "NOTFOUND", "FULL", "CANTOPEN",
+  "PROTOCOL", "EMPTY", "SCHEMA", "TOOBIG", "CONSTRAINT", "MISMATCH", "MISUSE",
   "NOLFS", "AUTH", "FORMAT", "RANGE", "NOTADB", [100] = "ROW", [101] = "DONE"
 } -- From 0 to 26.
 
@@ -63,16 +63,17 @@ do
   }
 
   local t = sqlconstants
-  local pre = "static const int32_t SQLITE_"  
+  local pre = "static const int32_t SQLITE_"
   for i=0,26    do t[#t+1] = pre..codes[i].."="..i..";\n" end
-  for i=100,101 do t[#t+1] = pre..codes[i].."="..i..";\n" end  
-  for i=1,5     do t[#t+1] = pre..types[i].."="..i..";\n" end  
+  for i=100,101 do t[#t+1] = pre..codes[i].."="..i..";\n" end
+  for i=1,5     do t[#t+1] = pre..types[i].."="..i..";\n" end
   pre = pre.."OPEN_"
-  for k,v in pairs(opens) do t[#t+1] = pre..k.."="..bit.tobit(v)..";\n" end  
+  for k,v in pairs(opens) do t[#t+1] = pre..k.."="..bit.tobit(v)..";\n" end
 end
 
 -- Cdef ------------------------------------------------------------------------
 -- SQLITE_*, OPEN_*
+
 ffi.cdef(table.concat(sqlconstants))
 
 -- sqlite3*, ljsqlite3_*
@@ -94,7 +95,7 @@ int sqlite3_close(sqlite3*);
 int sqlite3_busy_timeout(sqlite3*, int ms);
 
 // Statement.
-int sqlite3_prepare_v2(sqlite3 *conn, const char *zSql, int nByte, 
+int sqlite3_prepare_v2(sqlite3 *conn, const char *zSql, int nByte,
   sqlite3_stmt **ppStmt, const char **pzTail);
 int sqlite3_step(sqlite3_stmt*);
 int sqlite3_reset(sqlite3_stmt *pStmt);
@@ -118,6 +119,8 @@ int sqlite3_bind_double(sqlite3_stmt*, int, double);
 int sqlite3_bind_null(sqlite3_stmt*, int);
 int sqlite3_bind_text(sqlite3_stmt*, int, const char*, int n, void(*)(void*));
 int sqlite3_bind_blob(sqlite3_stmt*, int, const void*, int n, void(*)(void*));
+
+int sqlite3_bind_parameter_index(sqlite3_stmt *stmt, const char *name);
 
 // Clear bindings.
 int sqlite3_clear_bindings(sqlite3_stmt*);
@@ -275,10 +278,10 @@ local function loadcode(s, env)
 end
 
 -- Must always be called from *:_* function due to error level 4.
-local get_column = loadcode(sql_format(sql_get_code, "column", ",i"),	sql_env)
-local get_value  = loadcode(sql_format(sql_get_code, "value" , "  "),	sql_env)
-local set_column = loadcode(sql_format(sql_set_code, "bind"  , ",i"),	sql_env)
-local set_value  = loadcode(sql_format(sql_set_code, "result", "  "),	sql_env)
+local get_column = loadcode(sql_format(sql_get_code, "column", ",i"),   sql_env)
+local get_value  = loadcode(sql_format(sql_get_code, "value" , "  "),   sql_env)
+local set_column = loadcode(sql_format(sql_set_code, "bind"  , ",i"),   sql_env)
+local set_value  = loadcode(sql_format(sql_set_code, "result", "  "),   sql_env)
 
 -- Connection ------------------------------------------------------------------
 local open_modes = {
@@ -314,7 +317,7 @@ function conn_mt:close() T_open(self)
    -- Close all callbacks linked to conn.
   for _,v in pairs(conncb[self].scalar) do v:free() end
   for _,v in pairs(conncb[self].step)   do v:free() end
-  for _,v in pairs(conncb[self].final)  do v:free() end  
+  for _,v in pairs(conncb[self].final)  do v:free() end
   local code = sql.sqlite3_close(self._ptr)
   T_okcode(self._ptr, code)
   connstmt[self] = nil -- Table connstmt is not weak, need to clear manually.
@@ -413,13 +416,13 @@ local function scalarcb(name, f)
       sql.sqlite3_result_error(context, msg, #msg)
     else
       set_value(context, result)
-    end    
-  end 
+    end
+  end
   return ffi.cast("ljsqlite3_cbstep", sqlf)
 end
 
 -- Return the state for aggregate case (created via initstate()). We use the ptr
--- returned from aggregate_context() for tagging only, all the state data is 
+-- returned from aggregate_context() for tagging only, all the state data is
 -- handled from Lua side.
 local function getstate(context, initstate, size)
   -- Only pointer address relevant for indexing, size irrelevant.
@@ -445,8 +448,8 @@ local function stepcb(name, f, initstate)
     if not ok then
       local msg = "Lua registered step function "..name.." error: "..result
       sql.sqlite3_result_error(context, msg, #msg)
-    end    
-  end 
+    end
+  end
   return ffi.cast("ljsqlite3_cbstep", sqlf)
 end
 
@@ -463,7 +466,7 @@ local function finalcb(name, f, initstate)
     else
       set_value(context, result)
     end
-  end 
+  end
   return ffi.cast("ljsqlite3_cbfinal", sqlf)
 end
 
@@ -490,10 +493,10 @@ end
 conn_ct = ffi.metatype("struct { sqlite3* _ptr; bool _closed; }", conn_mt)
 
 -- Statement -------------------------------------------------------------------
-function stmt_mt:reset() T_open(self)  
-  -- Ignore possible error code, it would be repetition of error raised during 
+function stmt_mt:reset() T_open(self)
+  -- Ignore possible error code, it would be repetition of error raised during
   -- most recent evaluation of statement which would have been raised already.
-  sql.sqlite3_reset(self._ptr) 
+  sql.sqlite3_reset(self._ptr)
   self._code = sql.SQLITE_OK -- Always succeds.
   return self
 end
@@ -537,7 +540,7 @@ stmt_step = function(self, row, header)
     return nil
   else -- If code not DONE or ROW then it's error.
     E_conn(self._conn, self._code)
-  end  
+  end
 end
 stmt_mt._step = stmt_step
 
@@ -563,7 +566,7 @@ function stmt_mt:resultset(get, maxrecords) T_open(self)
     n = n + 1
     for i=1,#h do o[i][n] = r[i] end
   end
-  
+
   local out = { [0] = o[0] } -- Eventually copy colnames.
   if hasi then -- Use numeric indexes.
     for i=1,#h do out[i] = o[i] end
@@ -590,6 +593,17 @@ function stmt_mt:bind(...) T_open(self)
   return self
 end
 
+function stmt_mt:bindkv(t, pre) T_open(self)
+  pre = pre or ":"
+  for k,v in pairs(t) do
+    local param = sql.sqlite3_bind_parameter_index(self._ptr, pre..k)
+    if param ~= 0 then
+      self:_bind1(param, v)
+    end
+  end
+  return self
+end
+
 function stmt_mt:clearbind() T_open(self)
   local code = sql.sqlite3_clear_bindings(self._ptr)
   T_okcode(self._conn, code)
@@ -597,7 +611,7 @@ function stmt_mt:clearbind() T_open(self)
 end
 
 stmt_ct = ffi.metatype([[struct {
-  sqlite3_stmt* _ptr;  
+  sqlite3_stmt* _ptr;
   bool          _closed;
   sqlite3*      _conn;
   int32_t       _code;


### PR DESCRIPTION
This PR is hard to read because it removed a number of trailing whitespaces. Sorry about that!

All it does is provide `stmt:bindkv(table)` which allows for named parameters. Use:

```lua
local user = { name = "Joe Blow",
                       karma = 108,
                       sessionID = "...",
                       ..., }

conn:prepare "INSERT INTO users (name, karma) VALUES (:name, :karma)"

stmt:bindkv(user) -- equivalent to stmt:bindkv(user, ":")       
stmt:step():reset() -- etc
```         

This binds any parameter `:k` to an associated field `k` from the table parameter.  `$k` and `@k` can be bound as well: `stmt:bindkv(user, "$")`,`stmt:bindkv(user, "@")` or for `user[":name"]` use `stmt:bindkv(user,"")`. 

Thanks for this great library! I'm getting a lot out of it. 