### PR TITLE
Rows iterator

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -574,6 +574,19 @@ function stmt_mt:resultset(get, maxrecords) T_open(self)
   return out, n
 end
 
+-- iterator over rows
+function stmt_mt:rows()
+  return function() T_open(self)
+    local row = self:step()
+    if row then
+      return row
+    else
+      self:clearbind():reset()
+      return nil
+    end
+  end
+end
+
 -- Statement bind --------------------------------------------------------------
 function stmt_mt:_bind1(i, v)
   local code = set_column(self._ptr, v, i) -- Here indexing 1,N.


### PR DESCRIPTION


```lua
for row in stmt:rows() do
```

`stmt:rows()` is an iterator function like `pairs` or `ipairs`, performing one `:step()` at a time until all rows are returned. It `clearbinds` and `resets` the prepared statement.

```lua
local conn = sql.open("")
conn:exec[[
CREATE TABLE t(id TEXT, num REAL);
INSERT INTO t VALUES('myid1', 200);
INSERT INTO t VALUES('myid2', 400);
]]
local stmt = conn:prepare("SELECT * FROM t")
for row in stmt:rows() do
  print(unpack(row))
end

--> myid1 200
--> myid2 400
```